### PR TITLE
Fix for shield blocking mixin remapping issue.

### DIFF
--- a/src/main/resources/locomotion-common.mixins.json
+++ b/src/main/resources/locomotion-common.mixins.json
@@ -6,6 +6,7 @@
   "mixins": [
   ],
   "client": [
+    "MixinBlocksAttacks",
     "MixinCapeLayer",
     "MixinDebugScreenOverlay",
     "MixinElytraLayer",

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,11 +1,8 @@
-import io.github.pacifistmc.forgix.plugin.ForgixMergeExtension.FabricContainer
-
 plugins {
 	id("dev.kikugie.stonecutter")
 	id("dev.architectury.loom") version "1.10-SNAPSHOT" apply false
 	id("architectury-plugin") version "3.4-SNAPSHOT" apply false
 	id("com.github.johnrengelman.shadow") version "8.1.1" apply false
-	id("io.github.pacifistmc.forgix") version "1.2.9"
 }
 stonecutter active "1.21.5" /* [SC] DO NOT EDIT */
 
@@ -35,38 +32,4 @@ for (it in stonecutter.tree.nodes) {
 		group = "project"
 		dependsOn("run$type")
 	}
-}
-
-forgix {
-	val minecraft = stonecutter.current.version
-	val version = "${prop("mod.version")}+${minecraft}"
-	group = "${prop("mod.group")}.${prop("mod.id")}"
-	mergedJarName = "${prop("mod.id")}-${version}.jar"
-	outputDir = "build/libs/merged"
-
-	if (findProject(":fabric") != null) {
-		fabricContainer = FabricContainer().apply {
-			jarLocation = "versions/${minecraft}/build/libs/${prop("mod.id")}-fabric-${version}.jar"
-		}
-	}
-
-	if (findProject(":quilt") != null) {
-		quiltContainer = QuiltContainer().apply {
-			jarLocation = "versions/${minecraft}/build/libs/${prop("mod.id")}-quilt-${version}.jar"
-		}
-	}
-
-	if (findProject(":forge") != null) {
-		forgeContainer = ForgeContainer().apply {
-			jarLocation = "versions/${minecraft}/build/libs/${prop("mod.id")}-forge-${version}.jar"
-		}
-	}
-
-	if (findProject(":neoforge") != null) {
-		neoForgeContainer = NeoForgeContainer().apply {
-			jarLocation = "versions/${minecraft}/build/libs/${prop("mod.id")}-neoforge-${version}.jar"
-		}
-	}
-
-	removeDuplicate("${prop("mod.group")}.${prop("mod.id")}")
 }


### PR DESCRIPTION
The issue was an incompatibility between Stonecutter and Forgix causing the mixin refmap to be incorrect set during jar building, to fix this, I removed Forgix.